### PR TITLE
Fix asymmetric padding

### DIFF
--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -29,7 +29,7 @@
     <!-- List view fast scroll padding left -->
     <dimen name="fast_scroll_padding_left">8.0dip</dimen>
     <!-- List view fast scroll padding right -->
-    <dimen name="fast_scroll_padding_right">32.0dip</dimen>
+    <dimen name="fast_scroll_padding_right">8.0dip</dimen>
     <!-- grid view vertical and horizontal spacing -->
     <dimen name="grid_item_spacing">4.0dip</dimen>
     <!-- List item detailed height -->


### PR DESCRIPTION
The list of _playlists_, _songs_ and _genres_ is not centered, it's ugly. `8.0dip` it's the same padding of other pages (_recent_, _artists_, _albums_)
