### PR TITLE
Add playback of filesystem folders

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -25,6 +25,7 @@
         <item>@string/page_albums</item>
         <item>@string/page_songs</item>
         <item>@string/page_genres</item>
+        <item>@string/page_folders</item>
     </string-array>
 
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="page_songs">Songs</string>
     <string name="page_playlists">Playlists</string>
     <string name="page_genres">Genres</string>
+    <string name="page_folders">Folders</string>
 
     <!-- Option menu items -->
     <string name="menu_settings">Settings</string>

--- a/src/com/andrew/apollo/Config.java
+++ b/src/com/andrew/apollo/Config.java
@@ -60,6 +60,11 @@ public final class Config {
     public static final String MIME_TYPE = "mime_type";
 
     /**
+     * The music folder passed to the profile activity
+     */
+    public static final String FOLDER_PATH = "folder_path";
+
+    /**
      * Play from search intent
      */
     public static final String PLAY_FROM_SEARCH = "android.media.action.MEDIA_PLAY_FROM_SEARCH";

--- a/src/com/andrew/apollo/adapters/FolderAdapter.java
+++ b/src/com/andrew/apollo/adapters/FolderAdapter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2012 Andrew Neal Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.andrew.apollo.adapters;
+
+import java.io.File;
+
+import android.content.Context;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+
+import com.andrew.apollo.R;
+import com.andrew.apollo.ui.MusicHolder;
+import com.andrew.apollo.ui.MusicHolder.DataHolder;
+import com.andrew.apollo.ui.fragments.FolderFragment;
+
+/**
+ * This {@link ArrayAdapter} is used to display all of the music folders on
+ * a user's device for {@link FolderFragment} .
+ *
+ * @author Andrew Neal (andrewdneal@gmail.com)
+ */
+public class FolderAdapter extends ArrayAdapter<File> {
+
+    /**
+     * Number of views (TextView)
+     */
+    private static final int VIEW_TYPE_COUNT = 1;
+
+    /**
+     * The resource Id of the layout to inflate
+     */
+    private final int mLayoutId;
+
+    /**
+     * Used to cache the folder info
+     */
+    private DataHolder[] mData;
+
+    /**
+     * Constructor of <code>FileAdapter</code>
+     *
+     * @param context The {@link Context} to use.
+     * @param layoutId The resource Id of the view to inflate.
+     */
+    public FolderAdapter(final Context context, final int layoutId) {
+        super(context, 0);
+        mLayoutId = layoutId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public View getView(final int position, View convertView, final ViewGroup parent) {
+        // Recycle ViewHolder's items
+        MusicHolder holder;
+        if (convertView == null) {
+            convertView = LayoutInflater.from(getContext()).inflate(mLayoutId, parent, false);
+            holder = new MusicHolder(convertView);
+            // Hide the second and third lines of text
+            holder.mLineTwo.get().setVisibility(View.GONE);
+            holder.mLineThree.get().setVisibility(View.GONE);
+            // Make line one slightly larger
+            holder.mLineOne.get().setTextSize(TypedValue.COMPLEX_UNIT_PX,
+                    getContext().getResources().getDimension(R.dimen.text_size_large));
+            convertView.setTag(holder);
+        } else {
+            holder = (MusicHolder)convertView.getTag();
+        }
+
+        // Retrieve the data holder
+        final DataHolder dataHolder = mData[position];
+
+        // Set each folder name (line one)
+        holder.mLineOne.get().setText(dataHolder.mLineOne);
+        return convertView;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasStableIds() {
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getViewTypeCount() {
+        return VIEW_TYPE_COUNT;
+    }
+
+    /**
+     * Method used to cache the data used to populate the list or grid. The idea
+     * is to cache everything before {@code #getView(int, View, ViewGroup)} is
+     * called.
+     */
+    public void buildCache() {
+        mData = new DataHolder[getCount()];
+        for (int i = 0; i < getCount(); i++) {
+            // Build the artist
+            final File file = getItem(i);
+
+            // Build the data holder
+            mData[i] = new DataHolder();
+            // Folder names
+            mData[i].mLineOne = file.getName();
+        }
+    }
+
+    /**
+     * Method that unloads and clears the items in the adapter
+     */
+    public void unload() {
+        clear();
+        mData = null;
+    }
+
+}

--- a/src/com/andrew/apollo/adapters/PagerAdapter.java
+++ b/src/com/andrew/apollo/adapters/PagerAdapter.java
@@ -22,6 +22,7 @@ import android.view.ViewGroup;
 import com.andrew.apollo.R;
 import com.andrew.apollo.ui.fragments.AlbumFragment;
 import com.andrew.apollo.ui.fragments.ArtistFragment;
+import com.andrew.apollo.ui.fragments.FolderFragment;
 import com.andrew.apollo.ui.fragments.GenreFragment;
 import com.andrew.apollo.ui.fragments.PlaylistFragment;
 import com.andrew.apollo.ui.fragments.RecentFragment;
@@ -189,7 +190,11 @@ public class PagerAdapter extends FragmentPagerAdapter {
         /**
          * The genre fragment
          */
-        GENRE(GenreFragment.class);
+        GENRE(GenreFragment.class),
+        /**
+         * The file fragment
+         */
+        FILE(FolderFragment.class);
 
         private Class<? extends Fragment> mFragmentClass;
 

--- a/src/com/andrew/apollo/loaders/FolderLoader.java
+++ b/src/com/andrew/apollo/loaders/FolderLoader.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2012 Andrew Neal Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.andrew.apollo.loaders;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.provider.MediaStore;
+import android.provider.MediaStore.Audio.AudioColumns;
+
+import com.andrew.apollo.utils.Lists;
+import com.andrew.apollo.utils.PreferenceUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+
+import java.io.File;
+
+
+/**
+ * Used to query {@link MediaStore.Audio.Media.EXTERNAL_CONTENT_URI} and return
+ * folders that contain songs on a user's device.
+ *
+ * @author Andrew Neal (andrewdneal@gmail.com)
+ */
+public class FolderLoader extends WrappedAsyncTaskLoader<List<File>> {
+
+    /**
+     * The result
+     */
+    private final ArrayList<File> mFolders = Lists.newArrayList();
+
+    /**
+     * The {@link Cursor} used to run the query.
+     */
+    private Cursor mCursor;
+
+    /**
+     * Constructor of <code>FolderLoader</code>
+     *
+     * @param context The {@link Context} to use
+     */
+    public FolderLoader(final Context context) {
+        super(context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<File> loadInBackground() {
+        final HashSet<File> dirs = new HashSet<File>();
+        mCursor = makeSongCursor(getContext());
+        if (mCursor != null && mCursor.moveToFirst()) {
+            do {
+                // Copy the song filename and store the folder path.
+                File file = new File(mCursor.getString(0));
+                dirs.add(file.getAbsoluteFile().getParentFile());
+            } while (mCursor.moveToNext());
+        }
+        if (mCursor != null) {
+            mCursor.close();
+            mCursor = null;
+        }
+        mFolders.clear();
+        mFolders.addAll(dirs);
+        Collections.sort(mFolders, new Comparator<File>(){
+           public int compare(File fileA, File fileB) {
+            return fileA.getName().compareToIgnoreCase(fileB.getName());
+          }
+        });
+        return mFolders;
+    }
+
+    /**
+     * Creates the {@link Cursor} used to run the query.
+     *
+     * @param context The {@link Context} to use.
+     * @return The {@link Cursor} used to run the song query.
+     */
+    public static final Cursor makeSongCursor(final Context context) {
+        final StringBuilder mSelection = new StringBuilder();
+        mSelection.append(AudioColumns.IS_MUSIC + "=1"); //$NON-NLS-1$
+        mSelection.append(" AND " + AudioColumns.TITLE + " != ''"); //$NON-NLS-1$ //$NON-NLS-2$
+        return context.getContentResolver().query(MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                new String[] {
+                        /* 0 */
+                        MediaStore.Audio.AudioColumns.DATA
+                }, mSelection.toString(), null,
+                PreferenceUtils.getInstance(context).getSongSortOrder());
+    }
+}

--- a/src/com/andrew/apollo/loaders/FolderSongLoader.java
+++ b/src/com/andrew/apollo/loaders/FolderSongLoader.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2012 Andrew Neal Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.andrew.apollo.loaders;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.provider.MediaStore;
+import android.provider.MediaStore.MediaColumns;
+import android.provider.MediaStore.Audio.AudioColumns;
+
+import com.andrew.apollo.model.Song;
+import com.andrew.apollo.utils.Lists;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Used to query {@link MediaStore.Audio.Media.EXTERNAL_CONTENT_URI}
+ * and return songs for a particular folder on a user's device.
+ *
+ * @author Andrew Neal (andrewdneal@gmail.com)
+ */
+public class FolderSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
+
+    /**
+     * The result
+     */
+    private final ArrayList<Song> mSongList = Lists.newArrayList();
+
+    /**
+     * The {@link Cursor} used to run the query.
+     */
+    private Cursor mCursor;
+
+    /**
+     * The {@link File} of the folder to query.
+     */
+    private final File mFolder;
+
+    /**
+     * Constructor of <code>FolderSongHandler</code>
+     *
+     * @param context The {@link Context} to use.
+     * @param folder The {@link File} for the folder to query.
+     */
+    public FolderSongLoader(final Context context, final File folder) {
+        super(context);
+        mFolder = folder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Song> loadInBackground() {
+        // Create the Cursor
+        mCursor = makeFileSongCursor(getContext(), mFolder);
+        // Gather the data
+        if (mCursor != null && mCursor.moveToFirst()) {
+            do {
+                // Copy the song Id
+                final long id = mCursor.getLong(0);
+
+                // Copy the song name
+                final String songName = mCursor.getString(1);
+
+                // Copy the album name
+                final String album = mCursor.getString(2);
+
+                // Copy the artist name
+                final String artist = mCursor.getString(3);
+
+                // Copy the duration
+                final long duration = mCursor.getLong(4);
+
+                // Convert the duration into seconds
+                final int durationInSecs = (int) duration / 1000;
+
+                // Create a new song
+                final Song song = new Song(id, songName, artist, album, durationInSecs);
+
+                // Add everything up
+                mSongList.add(song);
+            } while (mCursor.moveToNext());
+        }
+        // Close the cursor
+        if (mCursor != null) {
+            mCursor.close();
+            mCursor = null;
+        }
+        return mSongList;
+    }
+
+    /**
+     * @param context The {@link Context} to use.
+     * @param folder The {@link File} for the folder to query.
+     * @return The {@link Cursor} used to run the query.
+     */
+    public static final Cursor makeFileSongCursor(final Context context, final File folder) {
+        // Find songs within the folder.
+        final StringBuilder selection = new StringBuilder();
+        selection.append(AudioColumns.IS_MUSIC + "=1"); //$NON-NLS-1$
+        selection.append(" AND " + MediaColumns.TITLE + "!=''"); //$NON-NLS-1$ //$NON-NLS-2$
+        selection.append(" AND " + MediaStore.Audio.AudioColumns.DATA + " LIKE ?"); //$NON-NLS-1$ //$NON-NLS-2$
+        return context.getContentResolver().query(
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI, new String[] {
+                        /* 0 */
+                        MediaStore.Audio.Media._ID,
+                        /* 1 */
+                        MediaStore.Audio.Media.TITLE,
+                        /* 2 */
+                        MediaStore.Audio.Media.ALBUM,
+                        /* 3 */
+                        MediaStore.Audio.Media.ARTIST,
+                        /* 4 */
+                        MediaStore.Audio.Media.DURATION,
+                }, selection.toString(),
+                new String[]{folder.toString() + '%'},
+                MediaStore.Audio.Media.DEFAULT_SORT_ORDER);
+    }
+}

--- a/src/com/andrew/apollo/ui/activities/ProfileActivity.java
+++ b/src/com/andrew/apollo/ui/activities/ProfileActivity.java
@@ -11,6 +11,8 @@
 
 package com.andrew.apollo.ui.activities;
 
+import java.io.File;
+
 import android.app.ActionBar;
 import android.app.Activity;
 import android.app.SearchManager;
@@ -38,6 +40,7 @@ import com.andrew.apollo.ui.fragments.profile.AlbumSongFragment;
 import com.andrew.apollo.ui.fragments.profile.ArtistAlbumFragment;
 import com.andrew.apollo.ui.fragments.profile.ArtistSongFragment;
 import com.andrew.apollo.ui.fragments.profile.FavoriteFragment;
+import com.andrew.apollo.ui.fragments.profile.FolderSongFragment;
 import com.andrew.apollo.ui.fragments.profile.GenreSongFragment;
 import com.andrew.apollo.ui.fragments.profile.LastAddedFragment;
 import com.andrew.apollo.ui.fragments.profile.PlaylistSongFragment;
@@ -222,6 +225,17 @@ public class ProfileActivity extends BaseActivity implements OnPageChangeListene
 
             // Action bar title = playlist name
             mResources.setTitle(mProfileName);
+        } else
+        // Set up the folder profile
+        if (isFolder()) {
+            // Add the carousel images
+            mTabCarousel.setPlaylistOrGenreProfileHeader(this, mProfileName);
+
+            // Folder profile fragments
+            mPagerAdapter.add(FolderSongFragment.class, mArguments);
+
+            // Action bar title = folder name
+            mResources.setTitle(mProfileName);
         }
 
         // Initialize the ViewPager
@@ -277,8 +291,10 @@ public class ProfileActivity extends BaseActivity implements OnPageChangeListene
      */
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
-        // Pin to Home screen
-        getMenuInflater().inflate(R.menu.add_to_homescreen, menu);
+        if (!isFolder()) {
+            // Pin to Home screen
+            getMenuInflater().inflate(R.menu.add_to_homescreen, menu);
+        }
         // Shuffle
         getMenuInflater().inflate(R.menu.shuffle, menu);
         // Sort orders
@@ -325,6 +341,9 @@ public class ProfileActivity extends BaseActivity implements OnPageChangeListene
                     list = MusicUtils.getSongListForAlbum(this, id);
                 } else if (isGenre()) {
                     list = MusicUtils.getSongListForGenre(this, id);
+                } else if (isFolder()) {
+                    list = MusicUtils.getSongListForFolder(this,
+                            new File(mArguments.getString(Config.FOLDER_PATH)));
                 }
                 if (isPlaylist()) {
                     MusicUtils.playPlaylist(this, id);
@@ -666,6 +685,13 @@ public class ProfileActivity extends BaseActivity implements OnPageChangeListene
      */
     private final boolean isLastAdded() {
         return mType.equals(getString(R.string.playlist_last_added));
+    }
+
+    /**
+     * @return True if the MIME type is "Folders", false otherwise.
+     */
+    private final boolean isFolder() {
+        return mType.equals(getString(R.string.page_folders));
     }
 
     private boolean isArtistSongPage() {

--- a/src/com/andrew/apollo/ui/fragments/FolderFragment.java
+++ b/src/com/andrew/apollo/ui/fragments/FolderFragment.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2012 Andrew Neal Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.andrew.apollo.ui.fragments;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.andrew.apollo.Config;
+import com.andrew.apollo.R;
+import com.andrew.apollo.adapters.FolderAdapter;
+import com.andrew.apollo.loaders.FolderLoader;
+import com.andrew.apollo.menu.FragmentMenuItems;
+import com.andrew.apollo.recycler.RecycleHolder;
+import com.andrew.apollo.ui.activities.ProfileActivity;
+import com.andrew.apollo.utils.MusicUtils;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * This class is used to display all of the music folders on a user's device.
+ *
+ * @author Andrew Neal (andrewdneal@gmail.com)
+ */
+public class FolderFragment extends Fragment implements LoaderCallbacks<List<File>>,
+        OnItemClickListener {
+
+    /**
+     * Used to keep context menu items from bleeding into other fragments
+     */
+    private static final int GROUP_ID = 5;
+
+    /**
+     * LoaderCallbacks identifier
+     */
+    private static final int LOADER = 0;
+
+    /**
+     * Fragment UI
+     */
+    private ViewGroup mRootView;
+
+    /**
+     * The adapter for the list
+     */
+    private FolderAdapter mAdapter;
+
+    /**
+     * The list view
+     */
+    private ListView mListView;
+
+    /**
+     * List of IDs of songs in the currently active folder
+     */
+    private long[] mSongList;
+
+    /**
+     * The {@link File} of the folder we are operating on
+     */
+    private File mFolder;
+
+    /**
+     * Empty constructor as per the {@link Fragment} documentation
+     */
+    public FolderFragment() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Create the adapter
+        mAdapter = new FolderAdapter(getActivity(), R.layout.list_item_simple);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
+            final Bundle savedInstanceState) {
+        // The View for the fragment's UI
+        mRootView = (ViewGroup)inflater.inflate(R.layout.list_base, container, false);
+        // Initialize the list
+        mListView = (ListView)mRootView.findViewById(R.id.list_base);
+        // Set the data behind the list
+        mListView.setAdapter(mAdapter);
+        // Release any references to the recycled Views
+        mListView.setRecyclerListener(new RecycleHolder());
+        // Listen for ContextMenus to be created
+        mListView.setOnCreateContextMenuListener(this);
+        // Show the albums and songs from the selected folder
+        mListView.setOnItemClickListener(this);
+        return mRootView;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onActivityCreated(final Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // Enable the options menu
+        setHasOptionsMenu(true);
+        // Start the loader
+        getLoaderManager().initLoader(LOADER, null, this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        // Get the position of the selected item
+        final AdapterContextMenuInfo info = (AdapterContextMenuInfo)menuInfo;
+        // Get the folder for the selected item
+        mFolder = mAdapter.getItem(info.position);
+        // Create a list of the folder's songs
+        mSongList = MusicUtils.getSongListForFolder(getActivity(), mFolder);
+
+        // Play the files within the folder
+        menu.add(GROUP_ID, FragmentMenuItems.PLAY_SELECTION, Menu.NONE,
+                R.string.context_menu_play_selection);
+        // Add the files to the queue
+        menu.add(GROUP_ID, FragmentMenuItems.ADD_TO_QUEUE, Menu.NONE, R.string.add_to_queue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean onContextItemSelected(final android.view.MenuItem item) {
+        if (item.getGroupId() == GROUP_ID) {
+            switch (item.getItemId()) {
+                case FragmentMenuItems.PLAY_SELECTION:
+                    MusicUtils.playAll(getActivity(), mSongList, 0, false);
+                    return true;
+                case FragmentMenuItems.ADD_TO_QUEUE:
+                    MusicUtils.addToQueue(getActivity(), mSongList);
+                    return true;
+                default:
+                    break;
+            }
+        }
+        return super.onContextItemSelected(item);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onItemClick(final AdapterView<?> parent, final View view, final int position,
+            final long id) {
+        mFolder = mAdapter.getItem(position);
+        // Create a new bundle to transfer the artist info
+        final Bundle bundle = new Bundle();
+        bundle.putLong(Config.ID, 0);
+        bundle.putString(Config.NAME, mFolder.getName());
+        bundle.putString(Config.MIME_TYPE, getString(R.string.page_folders));
+        bundle.putString(Config.FOLDER_PATH, mFolder.toString());
+
+        // Create the intent to launch the profile activity
+        final Intent intent = new Intent(getActivity(), ProfileActivity.class);
+        intent.putExtras(bundle);
+        startActivity(intent);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Loader<List<File>> onCreateLoader(final int id, final Bundle args) {
+        return new FolderLoader(getActivity());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onLoadFinished(final Loader<List<File>> loader, final List<File> data) {
+        // Check for any errors
+        if (data.isEmpty()) {
+            // Set the empty text
+            final TextView empty = (TextView)mRootView.findViewById(R.id.empty);
+            empty.setText(getString(R.string.empty_music));
+            mListView.setEmptyView(empty);
+            return;
+        }
+
+        // Start fresh
+        mAdapter.unload();
+        // Add the data to the adapter
+        for (final File folder : data) {
+            mAdapter.add(folder);
+        }
+        // Build the cache
+        mAdapter.buildCache();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onLoaderReset(final Loader<List<File>> loader) {
+        // Clear the data in the adapter
+        mAdapter.unload();
+    }
+
+}

--- a/src/com/andrew/apollo/ui/fragments/profile/FolderSongFragment.java
+++ b/src/com/andrew/apollo/ui/fragments/profile/FolderSongFragment.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright (C) 2012 Andrew Neal Licensed under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law
+ * or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.andrew.apollo.ui.fragments.profile;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.LoaderManager.LoaderCallbacks;
+import android.support.v4.content.Loader;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.SubMenu;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.AdapterView.AdapterContextMenuInfo;
+import android.widget.AdapterView.OnItemClickListener;
+import android.widget.ListView;
+
+import com.andrew.apollo.Config;
+import com.andrew.apollo.R;
+import com.andrew.apollo.adapters.ProfileSongAdapter;
+import com.andrew.apollo.loaders.FolderSongLoader;
+import com.andrew.apollo.menu.CreateNewPlaylist;
+import com.andrew.apollo.menu.DeleteDialog;
+import com.andrew.apollo.menu.FragmentMenuItems;
+import com.andrew.apollo.model.Song;
+import com.andrew.apollo.provider.FavoritesStore;
+import com.andrew.apollo.recycler.RecycleHolder;
+import com.andrew.apollo.utils.MusicUtils;
+import com.andrew.apollo.utils.NavUtils;
+import com.andrew.apollo.widgets.ProfileTabCarousel;
+import com.andrew.apollo.widgets.VerticalScrollListener;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * This class is used to display all of the songs from a particular folder.
+ *
+ * @author Andrew Neal (andrewdneal@gmail.com)
+ */
+public class FolderSongFragment extends Fragment implements LoaderCallbacks<List<Song>>,
+        OnItemClickListener {
+
+    /**
+     * Used to keep context menu items from bleeding into other fragments
+     */
+    private static final int GROUP_ID = 14;
+
+    /**
+     * LoaderCallbacks identifier
+     */
+    private static final int LOADER = 0;
+
+    /**
+     * The adapter for the list
+     */
+    private ProfileSongAdapter mAdapter;
+
+    /**
+     * The list view
+     */
+    private ListView mListView;
+
+    /**
+     * Represents a song
+     */
+    private Song mSong;
+
+    /**
+     * Position of a context menu item
+     */
+    private int mSelectedPosition;
+
+    /**
+     * Id of a context menu item
+     */
+    private long mSelectedId;
+
+    /**
+     * Song, album, and artist name used in the context menu
+     */
+    private String mSongName, mAlbumName, mArtistName;
+
+    /**
+     * Profile header
+     */
+    private ProfileTabCarousel mProfileTabCarousel;
+
+    /**
+     * Empty constructor as per the {@link Fragment} documentation
+     */
+    public FolderSongFragment() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onAttach(final Activity activity) {
+        super.onAttach(activity);
+        mProfileTabCarousel = (ProfileTabCarousel)activity
+                .findViewById(R.id.acivity_profile_base_tab_carousel);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Create the adapter
+        mAdapter = new ProfileSongAdapter(getActivity(), R.layout.list_item_simple,
+                ProfileSongAdapter.DISPLAY_PLAYLIST_SETTING);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
+            final Bundle savedInstanceState) {
+        // The View for the fragment's UI
+        final ViewGroup rootView = (ViewGroup)inflater.inflate(R.layout.list_base, container, false);
+        // Initialize the list
+        mListView = (ListView)rootView.findViewById(R.id.list_base);
+        // Set the data behind the list
+        mListView.setAdapter(mAdapter);
+        // Release any references to the recycled Views
+        mListView.setRecyclerListener(new RecycleHolder());
+        // Listen for ContextMenus to be created
+        mListView.setOnCreateContextMenuListener(this);
+        // Play the selected song
+        mListView.setOnItemClickListener(this);
+        // To help make scrolling smooth
+        mListView.setOnScrollListener(new VerticalScrollListener(null, mProfileTabCarousel, 0));
+        // Remove the scrollbars and padding for the fast scroll
+        mListView.setVerticalScrollBarEnabled(false);
+        mListView.setFastScrollEnabled(false);
+        mListView.setPadding(0, 0, 0, 0);
+        return rootView;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onActivityCreated(final Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // Enable the options menu
+        setHasOptionsMenu(true);
+        // Start the loader
+        final Bundle arguments = getArguments();
+        if (arguments != null) {
+            getLoaderManager().initLoader(LOADER, arguments, this);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putAll(getArguments() != null ? getArguments() : new Bundle());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        // Get the position of the selected item
+        final AdapterContextMenuInfo info = (AdapterContextMenuInfo)menuInfo;
+        mSelectedPosition = info.position - 1;
+        // Create a new song
+        mSong = mAdapter.getItem(mSelectedPosition);
+        mSelectedId = mSong.mSongId;
+        mSongName = mSong.mSongName;
+        mAlbumName = mSong.mAlbumName;
+        mArtistName = mSong.mArtistName;
+
+        // Play the song
+        menu.add(GROUP_ID, FragmentMenuItems.PLAY_SELECTION, Menu.NONE,
+                getString(R.string.context_menu_play_selection));
+
+        // Play the song
+        menu.add(GROUP_ID, FragmentMenuItems.PLAY_NEXT, Menu.NONE,
+                getString(R.string.context_menu_play_next));
+
+        // Add the song to the queue
+        menu.add(GROUP_ID, FragmentMenuItems.ADD_TO_QUEUE, Menu.NONE,
+                getString(R.string.add_to_queue));
+
+        // Add the song to a playlist
+        final SubMenu subMenu = menu.addSubMenu(GROUP_ID, FragmentMenuItems.ADD_TO_PLAYLIST,
+                Menu.NONE, R.string.add_to_playlist);
+        MusicUtils.makePlaylistMenu(getActivity(), GROUP_ID, subMenu, true);
+
+        // View more content by the song artist
+        menu.add(GROUP_ID, FragmentMenuItems.MORE_BY_ARTIST, Menu.NONE,
+                getString(R.string.context_menu_more_by_artist));
+
+        // Make the song a ringtone
+        menu.add(GROUP_ID, FragmentMenuItems.USE_AS_RINGTONE, Menu.NONE,
+                getString(R.string.context_menu_use_as_ringtone));
+
+        // Delete the song
+        menu.add(GROUP_ID, FragmentMenuItems.DELETE, Menu.NONE,
+                getString(R.string.context_menu_delete));
+    }
+
+    @Override
+    public boolean onContextItemSelected(final android.view.MenuItem item) {
+        if (item.getGroupId() == GROUP_ID) {
+            switch (item.getItemId()) {
+                case FragmentMenuItems.PLAY_SELECTION:
+                    MusicUtils.playAll(getActivity(), new long[] {
+                        mSelectedId
+                    }, 0, false);
+                    return true;
+                case FragmentMenuItems.PLAY_NEXT:
+                    MusicUtils.playNext(new long[] {
+                        mSelectedId
+                    });
+                    return true;
+                case FragmentMenuItems.ADD_TO_QUEUE:
+                    MusicUtils.addToQueue(getActivity(), new long[] {
+                        mSelectedId
+                    });
+                    return true;
+                case FragmentMenuItems.ADD_TO_FAVORITES:
+                    FavoritesStore.getInstance(getActivity()).addSongId(
+                            mSelectedId, mSongName, mAlbumName, mArtistName);
+                    return true;
+                case FragmentMenuItems.NEW_PLAYLIST:
+                    CreateNewPlaylist.getInstance(new long[] {
+                        mSelectedId
+                    }).show(getFragmentManager(), "CreatePlaylist"); //$NON-NLS-1$
+                    return true;
+                case FragmentMenuItems.PLAYLIST_SELECTED:
+                    final long mPlaylistId = item.getIntent().getLongExtra("playlist", 0); //$NON-NLS-1$
+                    MusicUtils.addToPlaylist(getActivity(), new long[] {
+                        mSelectedId
+                    }, mPlaylistId);
+                    return true;
+                case FragmentMenuItems.MORE_BY_ARTIST:
+                    NavUtils.openArtistProfile(getActivity(), mArtistName);
+                    return true;
+                case FragmentMenuItems.USE_AS_RINGTONE:
+                    MusicUtils.setRingtone(getActivity(), mSelectedId);
+                    return true;
+                case FragmentMenuItems.DELETE:
+                    DeleteDialog.newInstance(mSong.mSongName, new long[] {
+                        mSelectedId
+                    }, null).show(getFragmentManager(), "DeleteDialog"); //$NON-NLS-1$
+                    refresh();
+                    return true;
+                default:
+                    break;
+            }
+        }
+        return super.onContextItemSelected(item);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onItemClick(final AdapterView<?> parent, final View view, final int position,
+            final long id) {
+        MusicUtils.playAllFromUserItemClick(getActivity(), mAdapter, position);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Loader<List<Song>> onCreateLoader(final int id, final Bundle args) {
+        return new FolderSongLoader(getActivity(),
+                new File(args.getString(Config.FOLDER_PATH)));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onLoadFinished(final Loader<List<Song>> loader, final List<Song> data) {
+        // Check for any errors
+        if (data.isEmpty()) {
+            return;
+        }
+
+        // Start fresh
+        mAdapter.unload();
+        // Return the correct count
+        mAdapter.setCount(data);
+        // Add the data to the adapter
+        for (final Song song : data) {
+            mAdapter.add(song);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onLoaderReset(final Loader<List<Song>> loader) {
+        // Clear the data in the adapter
+        mAdapter.unload();
+    }
+
+    /**
+     * Restarts the loader.
+     */
+    public void refresh() {
+        // Scroll to the stop of the list before restarting the loader.
+        // Otherwise, if the user has scrolled enough to move the header, it
+        // becomes misplaced and needs to be reset.
+        mListView.setSelection(0);
+        // Wait a moment for the preference to change.
+        SystemClock.sleep(10);
+        getLoaderManager().restartLoader(LOADER, getArguments(), this);
+    }
+}

--- a/src/com/andrew/apollo/utils/MusicUtils.java
+++ b/src/com/andrew/apollo/utils/MusicUtils.java
@@ -558,6 +558,33 @@ public final class MusicUtils {
 
     /**
      * @param context The {@link Context} to use.
+     * @param folder The {@link File} of the folder to work on.
+     * @return The song list for a folder.
+     */
+    public static final long[] getSongListForFolder(final Context context, File folder) {
+        final String[] projection = new String[] {
+            BaseColumns._ID
+        };
+        final StringBuilder selection = new StringBuilder();
+        selection.append(AudioColumns.IS_MUSIC + "=1"); //$NON-NLS-1$
+        selection.append(" AND " + MediaColumns.TITLE + "!=''");  //$NON-NLS-1$//$NON-NLS-2$
+        selection.append(" AND " + MediaStore.Audio.AudioColumns.DATA + " LIKE ?"); //$NON-NLS-1$//$NON-NLS-2$
+        Cursor cursor = context.getContentResolver().query(
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                projection, selection.toString(),
+                new String[]{folder.toString() + '%'},
+                null);
+        if (cursor != null) {
+            final long[] mList = getSongListForCursor(cursor);
+            cursor.close();
+            cursor = null;
+            return mList;
+        }
+        return sEmptyList;
+    }
+
+    /**
+     * @param context The {@link Context} to use.
      * @param id The ID of the genre.
      * @return The song list for an genre.
      */

--- a/src/com/andrew/apollo/utils/ThemeUtils.java
+++ b/src/com/andrew/apollo/utils/ThemeUtils.java
@@ -301,8 +301,10 @@ public class ThemeUtils {
      */
     public void setAddToHomeScreenIcon(final Menu search) {
         final MenuItem pinnAction = search.findItem(R.id.menu_add_to_homescreen);
-        final String pinnIconId = "ic_action_pinn_to_home";
-        setMenuItemColor(pinnAction, "pinn_to_action", pinnIconId);
+        if (pinnAction != null) {
+            final String pinnIconId = "ic_action_pinn_to_home";
+            setMenuItemColor(pinnAction, "pinn_to_action", pinnIconId);
+        }
     }
 
     /**


### PR DESCRIPTION
Add a new UI fragment to play all audio files within a specific folder. The implementation is derived from the existing genre and playlist functionality. The music directories are discovered by querying EXTERNAL_CONTENT_URI for file paths and extracting the parent directory.

The "Add to home screen" menu item is currently not shown when playing folders.  Adding this is certainly possible, but requires a rework of ShortcutActivity to cope with ID strings, instead of numeric IDs (since
we can't generate numeric IDs for filesystem folders).

All other functionality (folder list, songs-within-folder list, playback, add-to-queue, shuffling, ...) should work fine.

Compared to [Evgeny Omelchenko's patch](http://review.cyanogenmod.org/#/c/72590/), this one actually works the way an end-user would expect. It displays folders with music and is actually able to play the music in the selected directory. Basically, I wrote this after finding the other patch unusable for my own music consumption.
